### PR TITLE
Restore schema TOC entries

### DIFF
--- a/docs/includes/endpoint-version-schedule/index.html
+++ b/docs/includes/endpoint-version-schedule/index.html
@@ -215,12 +215,12 @@
           <li>
             <a href="#endpoint-version-schedule" class="toc-h1 toc-link" data-title="Endpoint Version Schedule">Endpoint Version Schedule</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#data-holders" class="toc-h2 toc-link" data-title="Data Holders">Data Holders</a>
-                    </li>
-                    <li>
-                      <a href="#data-recipients" class="toc-h2 toc-link" data-title="Data Recipients">Data Recipients</a>
-                    </li>
+                  <li>
+                    <a href="#data-holders" class="toc-h2 toc-link" data-title="Data Holders">Data Holders</a>
+                  </li>
+                  <li>
+                    <a href="#data-recipients" class="toc-h2 toc-link" data-title="Data Recipients">Data Recipients</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/obsolete/get-metrics-v1.html
+++ b/docs/includes/obsolete/get-metrics-v1.html
@@ -215,42 +215,42 @@
             <li class="toc-child">
               <a href="#get-metrics-v1" class="toc-h1 toc-link" data-title="Get Metrics V1">Get Metrics V1</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#get-metrics" class="toc-h2 toc-link" data-title="Get Metrics">Get Metrics</a>
-                    </li>
-                    <li>
-                      <a href="#schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
-                    </li>
-                    <li>
-                      <a href="#tocSresponsemetricslist" class="toc-h2 toc-link" data-title="ResponseMetricsList">ResponseMetricsList</a>
-                    </li>
-                    <li>
-                      <a href="#tocSavailabilitymetrics" class="toc-h2 toc-link" data-title="AvailabilityMetrics">AvailabilityMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSperformancemetrics" class="toc-h2 toc-link" data-title="PerformanceMetrics">PerformanceMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSinvocationmetrics" class="toc-h2 toc-link" data-title="InvocationMetrics">InvocationMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSaverageresponsemetrics" class="toc-h2 toc-link" data-title="AverageResponseMetrics">AverageResponseMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSsessioncountmetrics" class="toc-h2 toc-link" data-title="SessionCountMetrics">SessionCountMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSaveragetpsmetrics" class="toc-h2 toc-link" data-title="AverageTPSMetrics">AverageTPSMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSpeaktpsmetrics" class="toc-h2 toc-link" data-title="PeakTPSMetrics">PeakTPSMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSerrormetrics" class="toc-h2 toc-link" data-title="ErrorMetrics">ErrorMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSrejectionmetrics" class="toc-h2 toc-link" data-title="RejectionMetrics">RejectionMetrics</a>
-                    </li>
+                  <li>
+                    <a href="#get-metrics" class="toc-h2 toc-link" data-title="Get Metrics">Get Metrics</a>
+                  </li>
+                  <li>
+                    <a href="#schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsemetricslist" class="toc-h2 toc-link" data-title="ResponseMetricsList">ResponseMetricsList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSavailabilitymetrics" class="toc-h2 toc-link" data-title="AvailabilityMetrics">AvailabilityMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSperformancemetrics" class="toc-h2 toc-link" data-title="PerformanceMetrics">PerformanceMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSinvocationmetrics" class="toc-h2 toc-link" data-title="InvocationMetrics">InvocationMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSaverageresponsemetrics" class="toc-h2 toc-link" data-title="AverageResponseMetrics">AverageResponseMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSsessioncountmetrics" class="toc-h2 toc-link" data-title="SessionCountMetrics">SessionCountMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSaveragetpsmetrics" class="toc-h2 toc-link" data-title="AverageTPSMetrics">AverageTPSMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSpeaktpsmetrics" class="toc-h2 toc-link" data-title="PeakTPSMetrics">PeakTPSMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSerrormetrics" class="toc-h2 toc-link" data-title="ErrorMetrics">ErrorMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSrejectionmetrics" class="toc-h2 toc-link" data-title="RejectionMetrics">RejectionMetrics</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/obsolete/get-metrics-v2.html
+++ b/docs/includes/obsolete/get-metrics-v2.html
@@ -215,48 +215,48 @@
             <li class="toc-child">
               <a href="#get-metrics-v2" class="toc-h1 toc-link" data-title="Get Metrics V2">Get Metrics V2</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#get-metrics" class="toc-h2 toc-link" data-title="Get Metrics">Get Metrics</a>
-                    </li>
-                    <li>
-                      <a href="#schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
-                    </li>
-                    <li>
-                      <a href="#tocSresponsemetricslistv2" class="toc-h2 toc-link" data-title="ResponseMetricsListV2">ResponseMetricsListV2</a>
-                    </li>
-                    <li>
-                      <a href="#tocSavailabilitymetrics" class="toc-h2 toc-link" data-title="AvailabilityMetrics">AvailabilityMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSperformancemetrics" class="toc-h2 toc-link" data-title="PerformanceMetrics">PerformanceMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSinvocationmetrics" class="toc-h2 toc-link" data-title="InvocationMetrics">InvocationMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSaverageresponsemetrics" class="toc-h2 toc-link" data-title="AverageResponseMetrics">AverageResponseMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSsessioncountmetrics" class="toc-h2 toc-link" data-title="SessionCountMetrics">SessionCountMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSaveragetpsmetrics" class="toc-h2 toc-link" data-title="AverageTPSMetrics">AverageTPSMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSpeaktpsmetrics" class="toc-h2 toc-link" data-title="PeakTPSMetrics">PeakTPSMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSerrormetrics" class="toc-h2 toc-link" data-title="ErrorMetrics">ErrorMetrics</a>
-                    </li>
-                    <li>
-                      <a href="#tocSrejectionmetricsv2" class="toc-h2 toc-link" data-title="RejectionMetricsV2">RejectionMetricsV2</a>
-                    </li>
-                    <li>
-                      <a href="#tocSlinks" class="toc-h2 toc-link" data-title="Links">Links</a>
-                    </li>
-                    <li>
-                      <a href="#tocSmeta" class="toc-h2 toc-link" data-title="Meta">Meta</a>
-                    </li>
+                  <li>
+                    <a href="#get-metrics" class="toc-h2 toc-link" data-title="Get Metrics">Get Metrics</a>
+                  </li>
+                  <li>
+                    <a href="#schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsemetricslistv2" class="toc-h2 toc-link" data-title="ResponseMetricsListV2">ResponseMetricsListV2</a>
+                  </li>
+                  <li>
+                    <a href="#tocSavailabilitymetrics" class="toc-h2 toc-link" data-title="AvailabilityMetrics">AvailabilityMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSperformancemetrics" class="toc-h2 toc-link" data-title="PerformanceMetrics">PerformanceMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSinvocationmetrics" class="toc-h2 toc-link" data-title="InvocationMetrics">InvocationMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSaverageresponsemetrics" class="toc-h2 toc-link" data-title="AverageResponseMetrics">AverageResponseMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSsessioncountmetrics" class="toc-h2 toc-link" data-title="SessionCountMetrics">SessionCountMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSaveragetpsmetrics" class="toc-h2 toc-link" data-title="AverageTPSMetrics">AverageTPSMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSpeaktpsmetrics" class="toc-h2 toc-link" data-title="PeakTPSMetrics">PeakTPSMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSerrormetrics" class="toc-h2 toc-link" data-title="ErrorMetrics">ErrorMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSrejectionmetricsv2" class="toc-h2 toc-link" data-title="RejectionMetricsV2">RejectionMetricsV2</a>
+                  </li>
+                  <li>
+                    <a href="#tocSlinks" class="toc-h2 toc-link" data-title="Links">Links</a>
+                  </li>
+                  <li>
+                    <a href="#tocSmeta" class="toc-h2 toc-link" data-title="Meta">Meta</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/obsolete/get-product-detail-v1.html
+++ b/docs/includes/obsolete/get-product-detail-v1.html
@@ -215,60 +215,60 @@
             <li class="toc-child">
               <a href="#get-product-detail-v1" class="toc-h1 toc-link" data-title="Get Product Detail V1">Get Product Detail V1</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#get-product-detail" class="toc-h2 toc-link" data-title="Get Product Detail">Get Product Detail</a>
-                    </li>
-                    <li>
-                      <a href="#tocSresponsebankingproductbyid" class="toc-h2 toc-link" data-title="ResponseBankingProductById">ResponseBankingProductById</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductdetail" class="toc-h2 toc-link" data-title="BankingProductDetail">BankingProductDetail</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductbundle" class="toc-h2 toc-link" data-title="BankingProductBundle">BankingProductBundle</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductfeature" class="toc-h2 toc-link" data-title="BankingProductFeature">BankingProductFeature</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductconstraint" class="toc-h2 toc-link" data-title="BankingProductConstraint">BankingProductConstraint</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproducteligibility" class="toc-h2 toc-link" data-title="BankingProductEligibility">BankingProductEligibility</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductfee" class="toc-h2 toc-link" data-title="BankingProductFee">BankingProductFee</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductdiscount" class="toc-h2 toc-link" data-title="BankingProductDiscount">BankingProductDiscount</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductdiscounteligibility" class="toc-h2 toc-link" data-title="BankingProductDiscountEligibility">BankingProductDiscountEligibility</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductdepositrate" class="toc-h2 toc-link" data-title="BankingProductDepositRate">BankingProductDepositRate</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductlendingrate" class="toc-h2 toc-link" data-title="BankingProductLendingRate">BankingProductLendingRate</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductratetier" class="toc-h2 toc-link" data-title="BankingProductRateTier">BankingProductRateTier</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductratecondition" class="toc-h2 toc-link" data-title="BankingProductRateCondition">BankingProductRateCondition</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproduct" class="toc-h2 toc-link" data-title="BankingProduct">BankingProduct</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductcategory" class="toc-h2 toc-link" data-title="BankingProductCategory">BankingProductCategory</a>
-                    </li>
-                    <li>
-                      <a href="#tocSlinks" class="toc-h2 toc-link" data-title="Links">Links</a>
-                    </li>
-                    <li>
-                      <a href="#tocSmeta" class="toc-h2 toc-link" data-title="Meta">Meta</a>
-                    </li>
+                  <li>
+                    <a href="#get-product-detail" class="toc-h2 toc-link" data-title="Get Product Detail">Get Product Detail</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingproductbyid" class="toc-h2 toc-link" data-title="ResponseBankingProductById">ResponseBankingProductById</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductdetail" class="toc-h2 toc-link" data-title="BankingProductDetail">BankingProductDetail</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductbundle" class="toc-h2 toc-link" data-title="BankingProductBundle">BankingProductBundle</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductfeature" class="toc-h2 toc-link" data-title="BankingProductFeature">BankingProductFeature</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductconstraint" class="toc-h2 toc-link" data-title="BankingProductConstraint">BankingProductConstraint</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproducteligibility" class="toc-h2 toc-link" data-title="BankingProductEligibility">BankingProductEligibility</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductfee" class="toc-h2 toc-link" data-title="BankingProductFee">BankingProductFee</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductdiscount" class="toc-h2 toc-link" data-title="BankingProductDiscount">BankingProductDiscount</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductdiscounteligibility" class="toc-h2 toc-link" data-title="BankingProductDiscountEligibility">BankingProductDiscountEligibility</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductdepositrate" class="toc-h2 toc-link" data-title="BankingProductDepositRate">BankingProductDepositRate</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductlendingrate" class="toc-h2 toc-link" data-title="BankingProductLendingRate">BankingProductLendingRate</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductratetier" class="toc-h2 toc-link" data-title="BankingProductRateTier">BankingProductRateTier</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductratecondition" class="toc-h2 toc-link" data-title="BankingProductRateCondition">BankingProductRateCondition</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproduct" class="toc-h2 toc-link" data-title="BankingProduct">BankingProduct</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductcategory" class="toc-h2 toc-link" data-title="BankingProductCategory">BankingProductCategory</a>
+                  </li>
+                  <li>
+                    <a href="#tocSlinks" class="toc-h2 toc-link" data-title="Links">Links</a>
+                  </li>
+                  <li>
+                    <a href="#tocSmeta" class="toc-h2 toc-link" data-title="Meta">Meta</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/obsolete/get-product-detail-v2.html
+++ b/docs/includes/obsolete/get-product-detail-v2.html
@@ -215,54 +215,54 @@
             <li class="toc-child">
               <a href="#get-product-detail-v2" class="toc-h1 toc-link" data-title="Get Product Detail V2">Get Product Detail V2</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#get-product-detail" class="toc-h2 toc-link" data-title="Get Product Detail">Get Product Detail</a>
-                    </li>
-                    <li>
-                      <a href="#tocSresponsebankingproductbyid" class="toc-h2 toc-link" data-title="ResponseBankingProductById">ResponseBankingProductById</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductdetail" class="toc-h2 toc-link" data-title="BankingProductDetail">BankingProductDetail</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductbundle" class="toc-h2 toc-link" data-title="BankingProductBundle">BankingProductBundle</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductfeature" class="toc-h2 toc-link" data-title="BankingProductFeature">BankingProductFeature</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductconstraint" class="toc-h2 toc-link" data-title="BankingProductConstraint">BankingProductConstraint</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproducteligibility" class="toc-h2 toc-link" data-title="BankingProductEligibility">BankingProductEligibility</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductfee" class="toc-h2 toc-link" data-title="BankingProductFee">BankingProductFee</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductdiscount" class="toc-h2 toc-link" data-title="BankingProductDiscount">BankingProductDiscount</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductdiscounteligibility" class="toc-h2 toc-link" data-title="BankingProductDiscountEligibility">BankingProductDiscountEligibility</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductdepositrate" class="toc-h2 toc-link" data-title="BankingProductDepositRate">BankingProductDepositRate</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductlendingrate" class="toc-h2 toc-link" data-title="BankingProductLendingRate">BankingProductLendingRate</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductratetier" class="toc-h2 toc-link" data-title="BankingProductRateTier">BankingProductRateTier</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductratecondition" class="toc-h2 toc-link" data-title="BankingProductRateCondition">BankingProductRateCondition</a>
-                    </li>
-                    <li>
-                      <a href="#tocSlinkspaginated" class="toc-h2 toc-link" data-title="LinksPaginated">LinksPaginated</a>
-                    </li>
-                    <li>
-                      <a href="#tocSmetapaginated" class="toc-h2 toc-link" data-title="MetaPaginated">MetaPaginated</a>
-                    </li>
+                  <li>
+                    <a href="#get-product-detail" class="toc-h2 toc-link" data-title="Get Product Detail">Get Product Detail</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingproductbyid" class="toc-h2 toc-link" data-title="ResponseBankingProductById">ResponseBankingProductById</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductdetail" class="toc-h2 toc-link" data-title="BankingProductDetail">BankingProductDetail</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductbundle" class="toc-h2 toc-link" data-title="BankingProductBundle">BankingProductBundle</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductfeature" class="toc-h2 toc-link" data-title="BankingProductFeature">BankingProductFeature</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductconstraint" class="toc-h2 toc-link" data-title="BankingProductConstraint">BankingProductConstraint</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproducteligibility" class="toc-h2 toc-link" data-title="BankingProductEligibility">BankingProductEligibility</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductfee" class="toc-h2 toc-link" data-title="BankingProductFee">BankingProductFee</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductdiscount" class="toc-h2 toc-link" data-title="BankingProductDiscount">BankingProductDiscount</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductdiscounteligibility" class="toc-h2 toc-link" data-title="BankingProductDiscountEligibility">BankingProductDiscountEligibility</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductdepositrate" class="toc-h2 toc-link" data-title="BankingProductDepositRate">BankingProductDepositRate</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductlendingrate" class="toc-h2 toc-link" data-title="BankingProductLendingRate">BankingProductLendingRate</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductratetier" class="toc-h2 toc-link" data-title="BankingProductRateTier">BankingProductRateTier</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductratecondition" class="toc-h2 toc-link" data-title="BankingProductRateCondition">BankingProductRateCondition</a>
+                  </li>
+                  <li>
+                    <a href="#tocSlinkspaginated" class="toc-h2 toc-link" data-title="LinksPaginated">LinksPaginated</a>
+                  </li>
+                  <li>
+                    <a href="#tocSmetapaginated" class="toc-h2 toc-link" data-title="MetaPaginated">MetaPaginated</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/obsolete/get-products-v1.html
+++ b/docs/includes/obsolete/get-products-v1.html
@@ -215,24 +215,24 @@
             <li class="toc-child">
               <a href="#get-products-v1" class="toc-h1 toc-link" data-title="Get Products V1">Get Products V1</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#get-products" class="toc-h2 toc-link" data-title="Get Products">Get Products</a>
-                    </li>
-                    <li>
-                      <a href="#tocSresponsebankingproductlist" class="toc-h2 toc-link" data-title="ResponseBankingProductList">ResponseBankingProductList</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproduct" class="toc-h2 toc-link" data-title="BankingProduct">BankingProduct</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductcategory" class="toc-h2 toc-link" data-title="BankingProductCategory">BankingProductCategory</a>
-                    </li>
-                    <li>
-                      <a href="#tocSlinkspaginated" class="toc-h2 toc-link" data-title="LinksPaginated">LinksPaginated</a>
-                    </li>
-                    <li>
-                      <a href="#tocSmetapaginated" class="toc-h2 toc-link" data-title="MetaPaginated">MetaPaginated</a>
-                    </li>
+                  <li>
+                    <a href="#get-products" class="toc-h2 toc-link" data-title="Get Products">Get Products</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingproductlist" class="toc-h2 toc-link" data-title="ResponseBankingProductList">ResponseBankingProductList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproduct" class="toc-h2 toc-link" data-title="BankingProduct">BankingProduct</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductcategory" class="toc-h2 toc-link" data-title="BankingProductCategory">BankingProductCategory</a>
+                  </li>
+                  <li>
+                    <a href="#tocSlinkspaginated" class="toc-h2 toc-link" data-title="LinksPaginated">LinksPaginated</a>
+                  </li>
+                  <li>
+                    <a href="#tocSmetapaginated" class="toc-h2 toc-link" data-title="MetaPaginated">MetaPaginated</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/obsolete/get-products-v2.html
+++ b/docs/includes/obsolete/get-products-v2.html
@@ -215,24 +215,24 @@
             <li class="toc-child">
               <a href="#get-products-v2" class="toc-h1 toc-link" data-title="Get Products V2">Get Products V2</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#get-products" class="toc-h2 toc-link" data-title="Get Products">Get Products</a>
-                    </li>
-                    <li>
-                      <a href="#tocSresponsebankingproductlist" class="toc-h2 toc-link" data-title="ResponseBankingProductList">ResponseBankingProductList</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductv2" class="toc-h2 toc-link" data-title="BankingProductV2">BankingProductV2</a>
-                    </li>
-                    <li>
-                      <a href="#tocSbankingproductcategory" class="toc-h2 toc-link" data-title="BankingProductCategory">BankingProductCategory</a>
-                    </li>
-                    <li>
-                      <a href="#tocSlinkspaginated" class="toc-h2 toc-link" data-title="LinksPaginated">LinksPaginated</a>
-                    </li>
-                    <li>
-                      <a href="#tocSmetapaginated" class="toc-h2 toc-link" data-title="MetaPaginated">MetaPaginated</a>
-                    </li>
+                  <li>
+                    <a href="#get-products" class="toc-h2 toc-link" data-title="Get Products">Get Products</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingproductlist" class="toc-h2 toc-link" data-title="ResponseBankingProductList">ResponseBankingProductList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductv2" class="toc-h2 toc-link" data-title="BankingProductV2">BankingProductV2</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductcategory" class="toc-h2 toc-link" data-title="BankingProductCategory">BankingProductCategory</a>
+                  </li>
+                  <li>
+                    <a href="#tocSlinkspaginated" class="toc-h2 toc-link" data-title="LinksPaginated">LinksPaginated</a>
+                  </li>
+                  <li>
+                    <a href="#tocSmetapaginated" class="toc-h2 toc-link" data-title="MetaPaginated">MetaPaginated</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.0.1.html
+++ b/docs/includes/releasenotes/releasenotes.1.0.1.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-0-1-release-notes" class="toc-h1 toc-link" data-title="V1.0.1 Release Notes">V1.0.1 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.1.0.html
+++ b/docs/includes/releasenotes/releasenotes.1.1.0.html
@@ -215,21 +215,21 @@
           <li>
             <a href="#v1-1-0-release-notes" class="toc-h1 toc-link" data-title="V1.1.0 Release Notes">V1.1.0 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#errata-for-v1-1-0" class="toc-h2 toc-link" data-title="Errata for v1.1.0">Errata for v1.1.0</a>
-                    </li>
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#errata-for-v1-1-0" class="toc-h2 toc-link" data-title="Errata for v1.1.0">Errata for v1.1.0</a>
+                  </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.1.1.html
+++ b/docs/includes/releasenotes/releasenotes.1.1.1.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-1-1-release-notes" class="toc-h1 toc-link" data-title="V1.1.1 Release Notes">V1.1.1 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.10.0.html
+++ b/docs/includes/releasenotes/releasenotes.1.10.0.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-10-0-release-notes" class="toc-h1 toc-link" data-title="V1.10.0 Release Notes">V1.10.0 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.11.0.html
+++ b/docs/includes/releasenotes/releasenotes.1.11.0.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-11-0-release-notes" class="toc-h1 toc-link" data-title="V1.11.0 Release Notes">V1.11.0 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.11.1.html
+++ b/docs/includes/releasenotes/releasenotes.1.11.1.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-11-1-release-notes" class="toc-h1 toc-link" data-title="V1.11.1 Release Notes">V1.11.1 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.12.0.html
+++ b/docs/includes/releasenotes/releasenotes.1.12.0.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-12-0-release-notes" class="toc-h1 toc-link" data-title="V1.12.0 Release Notes">V1.12.0 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.13.0.html
+++ b/docs/includes/releasenotes/releasenotes.1.13.0.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-13-0-release-notes" class="toc-h1 toc-link" data-title="V1.13.0 Release Notes">V1.13.0 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.14.0.html
+++ b/docs/includes/releasenotes/releasenotes.1.14.0.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-14-0-release-notes" class="toc-h1 toc-link" data-title="V1.14.0 Release Notes">V1.14.0 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.2.0.html
+++ b/docs/includes/releasenotes/releasenotes.1.2.0.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-2-0-release-notes" class="toc-h1 toc-link" data-title="V1.2.0 Release Notes">V1.2.0 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.3.0.html
+++ b/docs/includes/releasenotes/releasenotes.1.3.0.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-3-0-release-notes" class="toc-h1 toc-link" data-title="V1.3.0 Release Notes">V1.3.0 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.3.1.html
+++ b/docs/includes/releasenotes/releasenotes.1.3.1.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-3-1-release-notes" class="toc-h1 toc-link" data-title="V1.3.1 Release Notes">V1.3.1 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.4.0.html
+++ b/docs/includes/releasenotes/releasenotes.1.4.0.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-4-0-release-notes" class="toc-h1 toc-link" data-title="V1.4.0 Release Notes">V1.4.0 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.5.0.html
+++ b/docs/includes/releasenotes/releasenotes.1.5.0.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-5-0-release-notes" class="toc-h1 toc-link" data-title="V1.5.0 Release Notes">V1.5.0 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.5.1.html
+++ b/docs/includes/releasenotes/releasenotes.1.5.1.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-5-1-release-notes" class="toc-h1 toc-link" data-title="V1.5.1 Release Notes">V1.5.1 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.6.0.html
+++ b/docs/includes/releasenotes/releasenotes.1.6.0.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-6-0-release-notes" class="toc-h1 toc-link" data-title="V1.6.0 Release Notes">V1.6.0 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.7.0.html
+++ b/docs/includes/releasenotes/releasenotes.1.7.0.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-7-0-release-notes" class="toc-h1 toc-link" data-title="V1.7.0 Release Notes">V1.7.0 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.8.0.html
+++ b/docs/includes/releasenotes/releasenotes.1.8.0.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-8-0-release-notes" class="toc-h1 toc-link" data-title="V1.8.0 Release Notes">V1.8.0 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/includes/releasenotes/releasenotes.1.9.0.html
+++ b/docs/includes/releasenotes/releasenotes.1.9.0.html
@@ -215,18 +215,18 @@
           <li>
             <a href="#v1-9-0-release-notes" class="toc-h1 toc-link" data-title="V1.9.0 Release Notes">V1.9.0 Release Notes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
-                    </li>
-                    <li>
-                      <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
-                    </li>
-                    <li>
-                      <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
-                    </li>
-                    <li>
-                      <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
-                    </li>
+                  <li>
+                    <a href="#high-level-standards" class="toc-h2 toc-link" data-title="High Level Standards">High Level Standards</a>
+                  </li>
+                  <li>
+                    <a href="#api-end-points" class="toc-h2 toc-link" data-title="API End Points">API End Points</a>
+                  </li>
+                  <li>
+                    <a href="#information-security-profile" class="toc-h2 toc-link" data-title="Information Security Profile">Information Security Profile</a>
+                  </li>
+                  <li>
+                    <a href="#consumer-experience" class="toc-h2 toc-link" data-title="Consumer Experience">Consumer Experience</a>
+                  </li>
               </ul>
           </li>
       </ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -219,18 +219,18 @@
             <li class="toc-child">
               <a href="#introduction" class="toc-h1 toc-link" data-title="Introduction">Introduction</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#version" class="toc-h2 toc-link" data-title="Version">Version</a>
-                    </li>
-                    <li>
-                      <a href="#interpretation" class="toc-h2 toc-link" data-title="Interpretation">Interpretation</a>
-                    </li>
-                    <li>
-                      <a href="#future-dated-obligations" class="toc-h2 toc-link" data-title="Future Dated Obligations">Future Dated Obligations</a>
-                    </li>
-                    <li>
-                      <a href="#endpoint-version-schedule" class="toc-h2 toc-link" data-title="Endpoint Version Schedule">Endpoint Version Schedule</a>
-                    </li>
+                  <li>
+                    <a href="#version" class="toc-h2 toc-link" data-title="Version">Version</a>
+                  </li>
+                  <li>
+                    <a href="#interpretation" class="toc-h2 toc-link" data-title="Interpretation">Interpretation</a>
+                  </li>
+                  <li>
+                    <a href="#future-dated-obligations" class="toc-h2 toc-link" data-title="Future Dated Obligations">Future Dated Obligations</a>
+                  </li>
+                  <li>
+                    <a href="#endpoint-version-schedule" class="toc-h2 toc-link" data-title="Endpoint Version Schedule">Endpoint Version Schedule</a>
+                  </li>
               </ul>
           </li>
             <li class="toc-group">
@@ -239,39 +239,39 @@
             <li class="toc-child">
               <a href="#high-level-standards" class="toc-h1 toc-link" data-title="High Level Standards">High Level Standards</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#principles" class="toc-h2 toc-link" data-title="Principles">Principles</a>
-                    </li>
-                    <li>
-                      <a href="#versioning" class="toc-h2 toc-link" data-title="Versioning">Versioning</a>
-                    </li>
-                    <li>
-                      <a href="#uri-structure" class="toc-h2 toc-link" data-title="URI Structure">URI Structure</a>
-                    </li>
-                    <li>
-                      <a href="#http-headers" class="toc-h2 toc-link" data-title="HTTP Headers">HTTP Headers</a>
-                    </li>
-                    <li>
-                      <a href="#http-response-codes" class="toc-h2 toc-link" data-title="HTTP Response Codes">HTTP Response Codes</a>
-                    </li>
-                    <li>
-                      <a href="#payload-conventions" class="toc-h2 toc-link" data-title="Payload Conventions">Payload Conventions</a>
-                    </li>
-                    <li>
-                      <a href="#common-field-types" class="toc-h2 toc-link" data-title="Common Field Types">Common Field Types</a>
-                    </li>
-                    <li>
-                      <a href="#pagination" class="toc-h2 toc-link" data-title="Pagination">Pagination</a>
-                    </li>
-                    <li>
-                      <a href="#id-permanence" class="toc-h2 toc-link" data-title="ID Permanence">ID Permanence</a>
-                    </li>
-                    <li>
-                      <a href="#error-codes" class="toc-h2 toc-link" data-title="Error Codes">Error Codes</a>
-                    </li>
-                    <li>
-                      <a href="#extensibility" class="toc-h2 toc-link" data-title="Extensibility">Extensibility</a>
-                    </li>
+                  <li>
+                    <a href="#principles" class="toc-h2 toc-link" data-title="Principles">Principles</a>
+                  </li>
+                  <li>
+                    <a href="#versioning" class="toc-h2 toc-link" data-title="Versioning">Versioning</a>
+                  </li>
+                  <li>
+                    <a href="#uri-structure" class="toc-h2 toc-link" data-title="URI Structure">URI Structure</a>
+                  </li>
+                  <li>
+                    <a href="#http-headers" class="toc-h2 toc-link" data-title="HTTP Headers">HTTP Headers</a>
+                  </li>
+                  <li>
+                    <a href="#http-response-codes" class="toc-h2 toc-link" data-title="HTTP Response Codes">HTTP Response Codes</a>
+                  </li>
+                  <li>
+                    <a href="#payload-conventions" class="toc-h2 toc-link" data-title="Payload Conventions">Payload Conventions</a>
+                  </li>
+                  <li>
+                    <a href="#common-field-types" class="toc-h2 toc-link" data-title="Common Field Types">Common Field Types</a>
+                  </li>
+                  <li>
+                    <a href="#pagination" class="toc-h2 toc-link" data-title="Pagination">Pagination</a>
+                  </li>
+                  <li>
+                    <a href="#id-permanence" class="toc-h2 toc-link" data-title="ID Permanence">ID Permanence</a>
+                  </li>
+                  <li>
+                    <a href="#error-codes" class="toc-h2 toc-link" data-title="Error Codes">Error Codes</a>
+                  </li>
+                  <li>
+                    <a href="#extensibility" class="toc-h2 toc-link" data-title="Extensibility">Extensibility</a>
+                  </li>
               </ul>
           </li>
             <li class="toc-group">
@@ -280,33 +280,33 @@
             <li class="toc-child">
               <a href="#consumer-experience" class="toc-h1 toc-link" data-title="Consumer Experience">Consumer Experience</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#data-language-standards-common" class="toc-h2 toc-link" data-title="Data Language Standards: Common">Data Language Standards: Common</a>
-                    </li>
-                    <li>
-                      <a href="#banking-language" class="toc-h2 toc-link" data-title="Banking Language">Banking Language</a>
-                    </li>
-                    <li>
-                      <a href="#energy-language" class="toc-h2 toc-link" data-title="Energy Language">Energy Language</a>
-                    </li>
-                    <li>
-                      <a href="#accessibility-standards" class="toc-h2 toc-link" data-title="Accessibility Standards">Accessibility Standards</a>
-                    </li>
-                    <li>
-                      <a href="#consent-standards" class="toc-h2 toc-link" data-title="Consent Standards">Consent Standards</a>
-                    </li>
-                    <li>
-                      <a href="#authentication-standards" class="toc-h2 toc-link" data-title="Authentication Standards">Authentication Standards</a>
-                    </li>
-                    <li>
-                      <a href="#authorisation-standards" class="toc-h2 toc-link" data-title="Authorisation Standards">Authorisation Standards</a>
-                    </li>
-                    <li>
-                      <a href="#amending-authorisation-standards" class="toc-h2 toc-link" data-title="Amending Authorisation Standards">Amending Authorisation Standards</a>
-                    </li>
-                    <li>
-                      <a href="#withdrawal-standards" class="toc-h2 toc-link" data-title="Withdrawal Standards">Withdrawal Standards</a>
-                    </li>
+                  <li>
+                    <a href="#data-language-standards-common" class="toc-h2 toc-link" data-title="Data Language Standards: Common">Data Language Standards: Common</a>
+                  </li>
+                  <li>
+                    <a href="#banking-language" class="toc-h2 toc-link" data-title="Banking Language">Banking Language</a>
+                  </li>
+                  <li>
+                    <a href="#energy-language" class="toc-h2 toc-link" data-title="Energy Language">Energy Language</a>
+                  </li>
+                  <li>
+                    <a href="#accessibility-standards" class="toc-h2 toc-link" data-title="Accessibility Standards">Accessibility Standards</a>
+                  </li>
+                  <li>
+                    <a href="#consent-standards" class="toc-h2 toc-link" data-title="Consent Standards">Consent Standards</a>
+                  </li>
+                  <li>
+                    <a href="#authentication-standards" class="toc-h2 toc-link" data-title="Authentication Standards">Authentication Standards</a>
+                  </li>
+                  <li>
+                    <a href="#authorisation-standards" class="toc-h2 toc-link" data-title="Authorisation Standards">Authorisation Standards</a>
+                  </li>
+                  <li>
+                    <a href="#amending-authorisation-standards" class="toc-h2 toc-link" data-title="Amending Authorisation Standards">Amending Authorisation Standards</a>
+                  </li>
+                  <li>
+                    <a href="#withdrawal-standards" class="toc-h2 toc-link" data-title="Withdrawal Standards">Withdrawal Standards</a>
+                  </li>
               </ul>
           </li>
             <li class="toc-group">
@@ -315,129 +315,201 @@
             <li class="toc-child">
               <a href="#security-profile" class="toc-h1 toc-link" data-title="Security Profile">Security Profile</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#overview" class="toc-h2 toc-link" data-title="Overview">Overview</a>
-                    </li>
-                    <li>
-                      <a href="#cdr-federation" class="toc-h2 toc-link" data-title="CDR Federation">CDR Federation</a>
-                    </li>
-                    <li>
-                      <a href="#authentication-flows" class="toc-h2 toc-link" data-title="Authentication Flows">Authentication Flows</a>
-                    </li>
-                    <li>
-                      <a href="#client-authentication" class="toc-h2 toc-link" data-title="Client Authentication">Client Authentication</a>
-                    </li>
-                    <li>
-                      <a href="#client-registration" class="toc-h2 toc-link" data-title="Client Registration">Client Registration</a>
-                    </li>
-                    <li>
-                      <a href="#participant-statuses" class="toc-h2 toc-link" data-title="Participant Statuses">Participant Statuses</a>
-                    </li>
-                    <li>
-                      <a href="#oidc-client-types" class="toc-h2 toc-link" data-title="OIDC Client Types">OIDC Client Types</a>
-                    </li>
-                    <li>
-                      <a href="#consent" class="toc-h2 toc-link" data-title="Consent">Consent</a>
-                    </li>
-                    <li>
-                      <a href="#scopes-and-claims" class="toc-h2 toc-link" data-title="Scopes and Claims">Scopes and Claims</a>
-                    </li>
-                    <li>
-                      <a href="#tokens" class="toc-h2 toc-link" data-title="Tokens">Tokens</a>
-                    </li>
-                    <li>
-                      <a href="#identifiers-and-subject-types" class="toc-h2 toc-link" data-title="Identifiers and Subject Types">Identifiers and Subject Types</a>
-                    </li>
-                    <li>
-                      <a href="#levels-of-assurance-loas" class="toc-h2 toc-link" data-title="Levels of Assurance (LoAs)">Levels of Assurance (LoAs)</a>
-                    </li>
-                    <li>
-                      <a href="#transaction-security" class="toc-h2 toc-link" data-title="Transaction Security">Transaction Security</a>
-                    </li>
-                    <li>
-                      <a href="#certificate-management" class="toc-h2 toc-link" data-title="Certificate Management">Certificate Management</a>
-                    </li>
-                    <li>
-                      <a href="#cors" class="toc-h2 toc-link" data-title="CORS">CORS</a>
-                    </li>
-                    <li>
-                      <a href="#request-object" class="toc-h2 toc-link" data-title="Request Object">Request Object</a>
-                    </li>
-                    <li>
-                      <a href="#security-endpoints" class="toc-h2 toc-link" data-title="Security Endpoints">Security Endpoints</a>
-                    </li>
-                    <li>
-                      <a href="#normative-references" class="toc-h2 toc-link" data-title="Normative References">Normative References</a>
-                    </li>
-                    <li>
-                      <a href="#informative-references" class="toc-h2 toc-link" data-title="Informative References">Informative References</a>
-                    </li>
+                  <li>
+                    <a href="#overview" class="toc-h2 toc-link" data-title="Overview">Overview</a>
+                  </li>
+                  <li>
+                    <a href="#cdr-federation" class="toc-h2 toc-link" data-title="CDR Federation">CDR Federation</a>
+                  </li>
+                  <li>
+                    <a href="#authentication-flows" class="toc-h2 toc-link" data-title="Authentication Flows">Authentication Flows</a>
+                  </li>
+                  <li>
+                    <a href="#client-authentication" class="toc-h2 toc-link" data-title="Client Authentication">Client Authentication</a>
+                  </li>
+                  <li>
+                    <a href="#client-registration" class="toc-h2 toc-link" data-title="Client Registration">Client Registration</a>
+                  </li>
+                  <li>
+                    <a href="#participant-statuses" class="toc-h2 toc-link" data-title="Participant Statuses">Participant Statuses</a>
+                  </li>
+                  <li>
+                    <a href="#oidc-client-types" class="toc-h2 toc-link" data-title="OIDC Client Types">OIDC Client Types</a>
+                  </li>
+                  <li>
+                    <a href="#consent" class="toc-h2 toc-link" data-title="Consent">Consent</a>
+                  </li>
+                  <li>
+                    <a href="#scopes-and-claims" class="toc-h2 toc-link" data-title="Scopes and Claims">Scopes and Claims</a>
+                  </li>
+                  <li>
+                    <a href="#tokens" class="toc-h2 toc-link" data-title="Tokens">Tokens</a>
+                  </li>
+                  <li>
+                    <a href="#identifiers-and-subject-types" class="toc-h2 toc-link" data-title="Identifiers and Subject Types">Identifiers and Subject Types</a>
+                  </li>
+                  <li>
+                    <a href="#levels-of-assurance-loas" class="toc-h2 toc-link" data-title="Levels of Assurance (LoAs)">Levels of Assurance (LoAs)</a>
+                  </li>
+                  <li>
+                    <a href="#transaction-security" class="toc-h2 toc-link" data-title="Transaction Security">Transaction Security</a>
+                  </li>
+                  <li>
+                    <a href="#certificate-management" class="toc-h2 toc-link" data-title="Certificate Management">Certificate Management</a>
+                  </li>
+                  <li>
+                    <a href="#cors" class="toc-h2 toc-link" data-title="CORS">CORS</a>
+                  </li>
+                  <li>
+                    <a href="#request-object" class="toc-h2 toc-link" data-title="Request Object">Request Object</a>
+                  </li>
+                  <li>
+                    <a href="#security-endpoints" class="toc-h2 toc-link" data-title="Security Endpoints">Security Endpoints</a>
+                  </li>
+                  <li>
+                    <a href="#normative-references" class="toc-h2 toc-link" data-title="Normative References">Normative References</a>
+                  </li>
+                  <li>
+                    <a href="#informative-references" class="toc-h2 toc-link" data-title="Informative References">Informative References</a>
+                  </li>
               </ul>
           </li>
             <li class="toc-child">
               <a href="#dcr-apis" class="toc-h1 toc-link" data-title="DCR APIs">DCR APIs</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#register-data-recipient-oauth-client" class="toc-h2 toc-link" data-title="Register Data Recipient oAuth Client">Register Data Recipient oAuth Client</a>
-                    </li>
-                    <li>
-                      <a href="#get-oauth-client-registration" class="toc-h2 toc-link" data-title="Get oAuth Client Registration">Get oAuth Client Registration</a>
-                    </li>
-                    <li>
-                      <a href="#update-data-recipient-registration" class="toc-h2 toc-link" data-title="Update Data Recipient Registration">Update Data Recipient Registration</a>
-                    </li>
-                    <li>
-                      <a href="#delete-data-recipient-oauth-client-registration" class="toc-h2 toc-link" data-title="Delete Data Recipient oAuth Client Registration">Delete Data Recipient oAuth Client Registration</a>
-                    </li>
-                    <li>
-                      <a href="#cdr-dynamic-client-registration-api-schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
-                    </li>
+                  <li>
+                    <a href="#register-data-recipient-oauth-client" class="toc-h2 toc-link" data-title="Register Data Recipient oAuth Client">Register Data Recipient oAuth Client</a>
+                  </li>
+                  <li>
+                    <a href="#get-oauth-client-registration" class="toc-h2 toc-link" data-title="Get oAuth Client Registration">Get oAuth Client Registration</a>
+                  </li>
+                  <li>
+                    <a href="#update-data-recipient-registration" class="toc-h2 toc-link" data-title="Update Data Recipient Registration">Update Data Recipient Registration</a>
+                  </li>
+                  <li>
+                    <a href="#delete-data-recipient-oauth-client-registration" class="toc-h2 toc-link" data-title="Delete Data Recipient oAuth Client Registration">Delete Data Recipient oAuth Client Registration</a>
+                  </li>
+                  <li>
+                    <a href="#cdr-dynamic-client-registration-api-schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
+                  </li>
+                  <li>
+                    <a href="#tocSclientregistrationrequest" class="toc-h2 toc-link" data-title="ClientRegistrationRequest">ClientRegistrationRequest</a>
+                  </li>
+                  <li>
+                    <a href="#tocSregistrationproperties" class="toc-h2 toc-link" data-title="RegistrationProperties">RegistrationProperties</a>
+                  </li>
+                  <li>
+                    <a href="#tocSclientregistration" class="toc-h2 toc-link" data-title="ClientRegistration">ClientRegistration</a>
+                  </li>
+                  <li>
+                    <a href="#tocSregistrationerror" class="toc-h2 toc-link" data-title="RegistrationError">RegistrationError</a>
+                  </li>
               </ul>
           </li>
             <li class="toc-child">
               <a href="#register-apis" class="toc-h1 toc-link" data-title="Register APIs">Register APIs</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#base-urls" class="toc-h2 toc-link" data-title="Base URLs:">Base URLs:</a>
-                    </li>
-                    <li>
-                      <a href="#get-openid-provider-config" class="toc-h2 toc-link" data-title="Get OpenId Provider Config">Get OpenId Provider Config</a>
-                    </li>
-                    <li>
-                      <a href="#get-jwks" class="toc-h2 toc-link" data-title="Get JWKS">Get JWKS</a>
-                    </li>
-                    <li>
-                      <a href="#get-data-holder-brands" class="toc-h2 toc-link" data-title="Get Data Holder Brands">Get Data Holder Brands</a>
-                    </li>
-                    <li>
-                      <a href="#get-data-recipient-software-statement-assertion-ssa" class="toc-h2 toc-link" data-title="Get Data Recipient Software Statement Assertion (SSA)">Get Data Recipient Software Statement Assertion (SSA)</a>
-                    </li>
-                    <li>
-                      <a href="#get-data-recipient-software-products-statuses" class="toc-h2 toc-link" data-title="Get Data Recipient Software Products Statuses">Get Data Recipient Software Products Statuses</a>
-                    </li>
-                    <li>
-                      <a href="#get-data-recipient-statuses" class="toc-h2 toc-link" data-title="Get Data Recipient Statuses">Get Data Recipient Statuses</a>
-                    </li>
-                    <li>
-                      <a href="#get-data-recipients" class="toc-h2 toc-link" data-title="Get Data Recipients">Get Data Recipients</a>
-                    </li>
-                    <li>
-                      <a href="#cdr-participant-discovery-api-schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
-                    </li>
+                  <li>
+                    <a href="#base-urls" class="toc-h2 toc-link" data-title="Base URLs:">Base URLs:</a>
+                  </li>
+                  <li>
+                    <a href="#get-openid-provider-config" class="toc-h2 toc-link" data-title="Get OpenId Provider Config">Get OpenId Provider Config</a>
+                  </li>
+                  <li>
+                    <a href="#get-jwks" class="toc-h2 toc-link" data-title="Get JWKS">Get JWKS</a>
+                  </li>
+                  <li>
+                    <a href="#get-data-holder-brands" class="toc-h2 toc-link" data-title="Get Data Holder Brands">Get Data Holder Brands</a>
+                  </li>
+                  <li>
+                    <a href="#get-data-recipient-software-statement-assertion-ssa" class="toc-h2 toc-link" data-title="Get Data Recipient Software Statement Assertion (SSA)">Get Data Recipient Software Statement Assertion (SSA)</a>
+                  </li>
+                  <li>
+                    <a href="#get-data-recipient-software-products-statuses" class="toc-h2 toc-link" data-title="Get Data Recipient Software Products Statuses">Get Data Recipient Software Products Statuses</a>
+                  </li>
+                  <li>
+                    <a href="#get-data-recipient-statuses" class="toc-h2 toc-link" data-title="Get Data Recipient Statuses">Get Data Recipient Statuses</a>
+                  </li>
+                  <li>
+                    <a href="#get-data-recipients" class="toc-h2 toc-link" data-title="Get Data Recipients">Get Data Recipients</a>
+                  </li>
+                  <li>
+                    <a href="#cdr-participant-discovery-api-schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponseopenidproviderconfigmetadata" class="toc-h2 toc-link" data-title="ResponseOpenIDProviderConfigMetadata">ResponseOpenIDProviderConfigMetadata</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsejwks" class="toc-h2 toc-link" data-title="ResponseJWKS">ResponseJWKS</a>
+                  </li>
+                  <li>
+                    <a href="#tocSjwk" class="toc-h2 toc-link" data-title="JWK">JWK</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponseregisterdataholderbrandlist" class="toc-h2 toc-link" data-title="ResponseRegisterDataHolderBrandList">ResponseRegisterDataHolderBrandList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSregisterdataholderbrand" class="toc-h2 toc-link" data-title="RegisterDataHolderBrand">RegisterDataHolderBrand</a>
+                  </li>
+                  <li>
+                    <a href="#tocSsoftwareproductsstatuslist" class="toc-h2 toc-link" data-title="SoftwareProductsStatusList">SoftwareProductsStatusList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSsoftwareproductstatus" class="toc-h2 toc-link" data-title="SoftwareProductStatus">SoftwareProductStatus</a>
+                  </li>
+                  <li>
+                    <a href="#tocSdatarecipientsstatuslist" class="toc-h2 toc-link" data-title="DataRecipientsStatusList">DataRecipientsStatusList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSdatarecipientstatus" class="toc-h2 toc-link" data-title="DataRecipientStatus">DataRecipientStatus</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponseregisterdatarecipientlist" class="toc-h2 toc-link" data-title="ResponseRegisterDataRecipientList">ResponseRegisterDataRecipientList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSregisterdatarecipient" class="toc-h2 toc-link" data-title="RegisterDataRecipient">RegisterDataRecipient</a>
+                  </li>
+                  <li>
+                    <a href="#tocSdatarecipientbrandmetadata" class="toc-h2 toc-link" data-title="DataRecipientBrandMetaData">DataRecipientBrandMetaData</a>
+                  </li>
+                  <li>
+                    <a href="#tocSsoftwareproductmetadata" class="toc-h2 toc-link" data-title="SoftwareProductMetaData">SoftwareProductMetaData</a>
+                  </li>
+                  <li>
+                    <a href="#tocSlegalentitydetail" class="toc-h2 toc-link" data-title="LegalEntityDetail">LegalEntityDetail</a>
+                  </li>
+                  <li>
+                    <a href="#tocSregisterdataholderbrandserviceendpoint" class="toc-h2 toc-link" data-title="RegisterDataHolderBrandServiceEndpoint">RegisterDataHolderBrandServiceEndpoint</a>
+                  </li>
+                  <li>
+                    <a href="#tocSregisterdataholderauth" class="toc-h2 toc-link" data-title="RegisterDataHolderAuth">RegisterDataHolderAuth</a>
+                  </li>
+                  <li>
+                    <a href="#tocSlinkspaginated" class="toc-h2 toc-link" data-title="LinksPaginated">LinksPaginated</a>
+                  </li>
+                  <li>
+                    <a href="#tocSmetapaginated" class="toc-h2 toc-link" data-title="MetaPaginated">MetaPaginated</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponseerrorlist" class="toc-h2 toc-link" data-title="ResponseErrorList">ResponseErrorList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSerror" class="toc-h2 toc-link" data-title="Error">Error</a>
+                  </li>
               </ul>
           </li>
             <li class="toc-child">
               <a href="#authorisation-scopes" class="toc-h1 toc-link" data-title="Authorisation Scopes">Authorisation Scopes</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#public" class="toc-h2 toc-link" data-title="Public">Public</a>
-                    </li>
-                    <li>
-                      <a href="#cdr-data" class="toc-h2 toc-link" data-title="CDR Data">CDR Data</a>
-                    </li>
-                    <li>
-                      <a href="#admin-amp-registration" class="toc-h2 toc-link" data-title="Admin &amp; Registration">Admin &amp; Registration</a>
-                    </li>
+                  <li>
+                    <a href="#public" class="toc-h2 toc-link" data-title="Public">Public</a>
+                  </li>
+                  <li>
+                    <a href="#cdr-data" class="toc-h2 toc-link" data-title="CDR Data">CDR Data</a>
+                  </li>
+                  <li>
+                    <a href="#admin-amp-registration" class="toc-h2 toc-link" data-title="Admin &amp; Registration">Admin &amp; Registration</a>
+                  </li>
               </ul>
           </li>
             <li class="toc-group">
@@ -446,36 +518,36 @@
             <li class="toc-child">
               <a href="#non-functional-requirements" class="toc-h1 toc-link" data-title="Non-functional Requirements">Non-functional Requirements</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#definitions" class="toc-h2 toc-link" data-title="Definitions">Definitions</a>
-                    </li>
-                    <li>
-                      <a href="#session-requirements" class="toc-h2 toc-link" data-title="Session Requirements">Session Requirements</a>
-                    </li>
-                    <li>
-                      <a href="#availability-requirements" class="toc-h2 toc-link" data-title="Availability Requirements">Availability Requirements</a>
-                    </li>
-                    <li>
-                      <a href="#performance-requirements" class="toc-h2 toc-link" data-title="Performance Requirements">Performance Requirements</a>
-                    </li>
-                    <li>
-                      <a href="#traffic-thresholds" class="toc-h2 toc-link" data-title="Traffic Thresholds">Traffic Thresholds</a>
-                    </li>
-                    <li>
-                      <a href="#data-recipient-requirements" class="toc-h2 toc-link" data-title="Data Recipient Requirements">Data Recipient Requirements</a>
-                    </li>
-                    <li>
-                      <a href="#reporting-requirements" class="toc-h2 toc-link" data-title="Reporting Requirements">Reporting Requirements</a>
-                    </li>
-                    <li>
-                      <a href="#data-latency" class="toc-h2 toc-link" data-title="Data Latency">Data Latency</a>
-                    </li>
-                    <li>
-                      <a href="#data-quality" class="toc-h2 toc-link" data-title="Data Quality">Data Quality</a>
-                    </li>
-                    <li>
-                      <a href="#exemptions-to-protect-service" class="toc-h2 toc-link" data-title="Exemptions To Protect Service">Exemptions To Protect Service</a>
-                    </li>
+                  <li>
+                    <a href="#definitions" class="toc-h2 toc-link" data-title="Definitions">Definitions</a>
+                  </li>
+                  <li>
+                    <a href="#session-requirements" class="toc-h2 toc-link" data-title="Session Requirements">Session Requirements</a>
+                  </li>
+                  <li>
+                    <a href="#availability-requirements" class="toc-h2 toc-link" data-title="Availability Requirements">Availability Requirements</a>
+                  </li>
+                  <li>
+                    <a href="#performance-requirements" class="toc-h2 toc-link" data-title="Performance Requirements">Performance Requirements</a>
+                  </li>
+                  <li>
+                    <a href="#traffic-thresholds" class="toc-h2 toc-link" data-title="Traffic Thresholds">Traffic Thresholds</a>
+                  </li>
+                  <li>
+                    <a href="#data-recipient-requirements" class="toc-h2 toc-link" data-title="Data Recipient Requirements">Data Recipient Requirements</a>
+                  </li>
+                  <li>
+                    <a href="#reporting-requirements" class="toc-h2 toc-link" data-title="Reporting Requirements">Reporting Requirements</a>
+                  </li>
+                  <li>
+                    <a href="#data-latency" class="toc-h2 toc-link" data-title="Data Latency">Data Latency</a>
+                  </li>
+                  <li>
+                    <a href="#data-quality" class="toc-h2 toc-link" data-title="Data Quality">Data Quality</a>
+                  </li>
+                  <li>
+                    <a href="#exemptions-to-protect-service" class="toc-h2 toc-link" data-title="Exemptions To Protect Service">Exemptions To Protect Service</a>
+                  </li>
               </ul>
           </li>
             <li class="toc-group">
@@ -484,177 +556,624 @@
             <li class="toc-child">
               <a href="#banking-apis" class="toc-h1 toc-link" data-title="Banking APIs">Banking APIs</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#get-accounts" class="toc-h2 toc-link" data-title="Get Accounts">Get Accounts</a>
-                    </li>
-                    <li>
-                      <a href="#get-bulk-balances" class="toc-h2 toc-link" data-title="Get Bulk Balances">Get Bulk Balances</a>
-                    </li>
-                    <li>
-                      <a href="#get-balances-for-specific-accounts" class="toc-h2 toc-link" data-title="Get Balances For Specific Accounts">Get Balances For Specific Accounts</a>
-                    </li>
-                    <li>
-                      <a href="#get-account-balance" class="toc-h2 toc-link" data-title="Get Account Balance">Get Account Balance</a>
-                    </li>
-                    <li>
-                      <a href="#get-account-detail" class="toc-h2 toc-link" data-title="Get Account Detail">Get Account Detail</a>
-                    </li>
-                    <li>
-                      <a href="#get-transactions-for-account" class="toc-h2 toc-link" data-title="Get Transactions For Account">Get Transactions For Account</a>
-                    </li>
-                    <li>
-                      <a href="#get-transaction-detail" class="toc-h2 toc-link" data-title="Get Transaction Detail">Get Transaction Detail</a>
-                    </li>
-                    <li>
-                      <a href="#get-direct-debits-for-account" class="toc-h2 toc-link" data-title="Get Direct Debits For Account">Get Direct Debits For Account</a>
-                    </li>
-                    <li>
-                      <a href="#get-bulk-direct-debits" class="toc-h2 toc-link" data-title="Get Bulk Direct Debits">Get Bulk Direct Debits</a>
-                    </li>
-                    <li>
-                      <a href="#get-direct-debits-for-specific-accounts" class="toc-h2 toc-link" data-title="Get Direct Debits For Specific Accounts">Get Direct Debits For Specific Accounts</a>
-                    </li>
-                    <li>
-                      <a href="#get-scheduled-payments-for-account" class="toc-h2 toc-link" data-title="Get Scheduled Payments for Account">Get Scheduled Payments for Account</a>
-                    </li>
-                    <li>
-                      <a href="#get-scheduled-payments-bulk" class="toc-h2 toc-link" data-title="Get Scheduled Payments Bulk">Get Scheduled Payments Bulk</a>
-                    </li>
-                    <li>
-                      <a href="#get-scheduled-payments-for-specific-accounts" class="toc-h2 toc-link" data-title="Get Scheduled Payments For Specific Accounts">Get Scheduled Payments For Specific Accounts</a>
-                    </li>
-                    <li>
-                      <a href="#get-payees" class="toc-h2 toc-link" data-title="Get Payees">Get Payees</a>
-                    </li>
-                    <li>
-                      <a href="#get-payee-detail" class="toc-h2 toc-link" data-title="Get Payee Detail">Get Payee Detail</a>
-                    </li>
-                    <li>
-                      <a href="#get-products" class="toc-h2 toc-link" data-title="Get Products">Get Products</a>
-                    </li>
-                    <li>
-                      <a href="#get-product-detail" class="toc-h2 toc-link" data-title="Get Product Detail">Get Product Detail</a>
-                    </li>
-                    <li>
-                      <a href="#cdr-banking-api-schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
-                    </li>
-                    <li>
-                      <a href="#product-categories" class="toc-h2 toc-link" data-title="Product Categories">Product Categories</a>
-                    </li>
-                    <li>
-                      <a href="#product-amp-account-components" class="toc-h2 toc-link" data-title="Product &amp; Account Components">Product &amp; Account Components</a>
-                    </li>
+                  <li>
+                    <a href="#get-accounts" class="toc-h2 toc-link" data-title="Get Accounts">Get Accounts</a>
+                  </li>
+                  <li>
+                    <a href="#get-bulk-balances" class="toc-h2 toc-link" data-title="Get Bulk Balances">Get Bulk Balances</a>
+                  </li>
+                  <li>
+                    <a href="#get-balances-for-specific-accounts" class="toc-h2 toc-link" data-title="Get Balances For Specific Accounts">Get Balances For Specific Accounts</a>
+                  </li>
+                  <li>
+                    <a href="#get-account-balance" class="toc-h2 toc-link" data-title="Get Account Balance">Get Account Balance</a>
+                  </li>
+                  <li>
+                    <a href="#get-account-detail" class="toc-h2 toc-link" data-title="Get Account Detail">Get Account Detail</a>
+                  </li>
+                  <li>
+                    <a href="#get-transactions-for-account" class="toc-h2 toc-link" data-title="Get Transactions For Account">Get Transactions For Account</a>
+                  </li>
+                  <li>
+                    <a href="#get-transaction-detail" class="toc-h2 toc-link" data-title="Get Transaction Detail">Get Transaction Detail</a>
+                  </li>
+                  <li>
+                    <a href="#get-direct-debits-for-account" class="toc-h2 toc-link" data-title="Get Direct Debits For Account">Get Direct Debits For Account</a>
+                  </li>
+                  <li>
+                    <a href="#get-bulk-direct-debits" class="toc-h2 toc-link" data-title="Get Bulk Direct Debits">Get Bulk Direct Debits</a>
+                  </li>
+                  <li>
+                    <a href="#get-direct-debits-for-specific-accounts" class="toc-h2 toc-link" data-title="Get Direct Debits For Specific Accounts">Get Direct Debits For Specific Accounts</a>
+                  </li>
+                  <li>
+                    <a href="#get-scheduled-payments-for-account" class="toc-h2 toc-link" data-title="Get Scheduled Payments for Account">Get Scheduled Payments for Account</a>
+                  </li>
+                  <li>
+                    <a href="#get-scheduled-payments-bulk" class="toc-h2 toc-link" data-title="Get Scheduled Payments Bulk">Get Scheduled Payments Bulk</a>
+                  </li>
+                  <li>
+                    <a href="#get-scheduled-payments-for-specific-accounts" class="toc-h2 toc-link" data-title="Get Scheduled Payments For Specific Accounts">Get Scheduled Payments For Specific Accounts</a>
+                  </li>
+                  <li>
+                    <a href="#get-payees" class="toc-h2 toc-link" data-title="Get Payees">Get Payees</a>
+                  </li>
+                  <li>
+                    <a href="#get-payee-detail" class="toc-h2 toc-link" data-title="Get Payee Detail">Get Payee Detail</a>
+                  </li>
+                  <li>
+                    <a href="#get-products" class="toc-h2 toc-link" data-title="Get Products">Get Products</a>
+                  </li>
+                  <li>
+                    <a href="#get-product-detail" class="toc-h2 toc-link" data-title="Get Product Detail">Get Product Detail</a>
+                  </li>
+                  <li>
+                    <a href="#cdr-banking-api-schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
+                  </li>
+                  <li>
+                    <a href="#tocSrequestaccountids" class="toc-h2 toc-link" data-title="RequestAccountIds">RequestAccountIds</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingproductlist" class="toc-h2 toc-link" data-title="ResponseBankingProductList">ResponseBankingProductList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductv3" class="toc-h2 toc-link" data-title="BankingProductV3">BankingProductV3</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingproductbyid" class="toc-h2 toc-link" data-title="ResponseBankingProductById">ResponseBankingProductById</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductdetailv3" class="toc-h2 toc-link" data-title="BankingProductDetailV3">BankingProductDetailV3</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductbundle" class="toc-h2 toc-link" data-title="BankingProductBundle">BankingProductBundle</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductfeature" class="toc-h2 toc-link" data-title="BankingProductFeature">BankingProductFeature</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductconstraint" class="toc-h2 toc-link" data-title="BankingProductConstraint">BankingProductConstraint</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproducteligibility" class="toc-h2 toc-link" data-title="BankingProductEligibility">BankingProductEligibility</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductfee" class="toc-h2 toc-link" data-title="BankingProductFee">BankingProductFee</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductdiscount" class="toc-h2 toc-link" data-title="BankingProductDiscount">BankingProductDiscount</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductdiscounteligibility" class="toc-h2 toc-link" data-title="BankingProductDiscountEligibility">BankingProductDiscountEligibility</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductdepositrate" class="toc-h2 toc-link" data-title="BankingProductDepositRate">BankingProductDepositRate</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductlendingratev2" class="toc-h2 toc-link" data-title="BankingProductLendingRateV2">BankingProductLendingRateV2</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductratetierv3" class="toc-h2 toc-link" data-title="BankingProductRateTierV3">BankingProductRateTierV3</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductratecondition" class="toc-h2 toc-link" data-title="BankingProductRateCondition">BankingProductRateCondition</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingaccountlist" class="toc-h2 toc-link" data-title="ResponseBankingAccountList">ResponseBankingAccountList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingaccount" class="toc-h2 toc-link" data-title="BankingAccount">BankingAccount</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingaccountbyid" class="toc-h2 toc-link" data-title="ResponseBankingAccountById">ResponseBankingAccountById</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingaccountdetail" class="toc-h2 toc-link" data-title="BankingAccountDetail">BankingAccountDetail</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingtermdepositaccount" class="toc-h2 toc-link" data-title="BankingTermDepositAccount">BankingTermDepositAccount</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingcreditcardaccount" class="toc-h2 toc-link" data-title="BankingCreditCardAccount">BankingCreditCardAccount</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingloanaccount" class="toc-h2 toc-link" data-title="BankingLoanAccount">BankingLoanAccount</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingtransactionlist" class="toc-h2 toc-link" data-title="ResponseBankingTransactionList">ResponseBankingTransactionList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingtransaction" class="toc-h2 toc-link" data-title="BankingTransaction">BankingTransaction</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingtransactionbyid" class="toc-h2 toc-link" data-title="ResponseBankingTransactionById">ResponseBankingTransactionById</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingtransactiondetail" class="toc-h2 toc-link" data-title="BankingTransactionDetail">BankingTransactionDetail</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingaccountsbalancelist" class="toc-h2 toc-link" data-title="ResponseBankingAccountsBalanceList">ResponseBankingAccountsBalanceList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingaccountsbalancebyid" class="toc-h2 toc-link" data-title="ResponseBankingAccountsBalanceById">ResponseBankingAccountsBalanceById</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingbalance" class="toc-h2 toc-link" data-title="BankingBalance">BankingBalance</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingbalancepurse" class="toc-h2 toc-link" data-title="BankingBalancePurse">BankingBalancePurse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingpayeelist" class="toc-h2 toc-link" data-title="ResponseBankingPayeeList">ResponseBankingPayeeList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingpayeebyid" class="toc-h2 toc-link" data-title="ResponseBankingPayeeById">ResponseBankingPayeeById</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingpayee" class="toc-h2 toc-link" data-title="BankingPayee">BankingPayee</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingpayeedetail" class="toc-h2 toc-link" data-title="BankingPayeeDetail">BankingPayeeDetail</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingdomesticpayee" class="toc-h2 toc-link" data-title="BankingDomesticPayee">BankingDomesticPayee</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingdomesticpayeeaccount" class="toc-h2 toc-link" data-title="BankingDomesticPayeeAccount">BankingDomesticPayeeAccount</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingdomesticpayeecard" class="toc-h2 toc-link" data-title="BankingDomesticPayeeCard">BankingDomesticPayeeCard</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingdomesticpayeepayid" class="toc-h2 toc-link" data-title="BankingDomesticPayeePayId">BankingDomesticPayeePayId</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingbillerpayee" class="toc-h2 toc-link" data-title="BankingBillerPayee">BankingBillerPayee</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankinginternationalpayee" class="toc-h2 toc-link" data-title="BankingInternationalPayee">BankingInternationalPayee</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingdirectdebitauthorisationlist" class="toc-h2 toc-link" data-title="ResponseBankingDirectDebitAuthorisationList">ResponseBankingDirectDebitAuthorisationList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingdirectdebit" class="toc-h2 toc-link" data-title="BankingDirectDebit">BankingDirectDebit</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingauthorisedentity" class="toc-h2 toc-link" data-title="BankingAuthorisedEntity">BankingAuthorisedEntity</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsebankingscheduledpaymentslist" class="toc-h2 toc-link" data-title="ResponseBankingScheduledPaymentsList">ResponseBankingScheduledPaymentsList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingscheduledpayment" class="toc-h2 toc-link" data-title="BankingScheduledPayment">BankingScheduledPayment</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingscheduledpaymentset" class="toc-h2 toc-link" data-title="BankingScheduledPaymentSet">BankingScheduledPaymentSet</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingscheduledpaymentto" class="toc-h2 toc-link" data-title="BankingScheduledPaymentTo">BankingScheduledPaymentTo</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingscheduledpaymentfrom" class="toc-h2 toc-link" data-title="BankingScheduledPaymentFrom">BankingScheduledPaymentFrom</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingscheduledpaymentrecurrence" class="toc-h2 toc-link" data-title="BankingScheduledPaymentRecurrence">BankingScheduledPaymentRecurrence</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingscheduledpaymentrecurrenceonceoff" class="toc-h2 toc-link" data-title="BankingScheduledPaymentRecurrenceOnceOff">BankingScheduledPaymentRecurrenceOnceOff</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingscheduledpaymentrecurrenceintervalschedule" class="toc-h2 toc-link" data-title="BankingScheduledPaymentRecurrenceIntervalSchedule">BankingScheduledPaymentRecurrenceIntervalSchedule</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingscheduledpaymentinterval" class="toc-h2 toc-link" data-title="BankingScheduledPaymentInterval">BankingScheduledPaymentInterval</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingscheduledpaymentrecurrencelastweekday" class="toc-h2 toc-link" data-title="BankingScheduledPaymentRecurrenceLastWeekday">BankingScheduledPaymentRecurrenceLastWeekday</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingscheduledpaymentrecurrenceeventbased" class="toc-h2 toc-link" data-title="BankingScheduledPaymentRecurrenceEventBased">BankingScheduledPaymentRecurrenceEventBased</a>
+                  </li>
+                  <li>
+                    <a href="#tocScommonphysicaladdress" class="toc-h2 toc-link" data-title="CommonPhysicalAddress">CommonPhysicalAddress</a>
+                  </li>
+                  <li>
+                    <a href="#tocScommonsimpleaddress" class="toc-h2 toc-link" data-title="CommonSimpleAddress">CommonSimpleAddress</a>
+                  </li>
+                  <li>
+                    <a href="#tocScommonpafaddress" class="toc-h2 toc-link" data-title="CommonPAFAddress">CommonPAFAddress</a>
+                  </li>
+                  <li>
+                    <a href="#tocSlinks" class="toc-h2 toc-link" data-title="Links">Links</a>
+                  </li>
+                  <li>
+                    <a href="#tocSmeta" class="toc-h2 toc-link" data-title="Meta">Meta</a>
+                  </li>
+                  <li>
+                    <a href="#tocSlinkspaginated" class="toc-h2 toc-link" data-title="LinksPaginated">LinksPaginated</a>
+                  </li>
+                  <li>
+                    <a href="#tocSmetapaginated" class="toc-h2 toc-link" data-title="MetaPaginated">MetaPaginated</a>
+                  </li>
+                  <li>
+                    <a href="#tocSmetaerror" class="toc-h2 toc-link" data-title="MetaError">MetaError</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponseerrorlistv2" class="toc-h2 toc-link" data-title="ResponseErrorListV2">ResponseErrorListV2</a>
+                  </li>
+                  <li>
+                    <a href="#tocSbankingproductcategory" class="toc-h2 toc-link" data-title="BankingProductCategory">BankingProductCategory</a>
+                  </li>
+                  <li>
+                    <a href="#product-categories" class="toc-h2 toc-link" data-title="Product Categories">Product Categories</a>
+                  </li>
+                  <li>
+                    <a href="#product-amp-account-components" class="toc-h2 toc-link" data-title="Product &amp; Account Components">Product &amp; Account Components</a>
+                  </li>
               </ul>
           </li>
             <li class="toc-child">
               <a href="#energy-apis" class="toc-h1 toc-link" data-title="Energy APIs">Energy APIs</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#get-generic-plans" class="toc-h2 toc-link" data-title="Get Generic Plans">Get Generic Plans</a>
-                    </li>
-                    <li>
-                      <a href="#get-generic-plan-detail" class="toc-h2 toc-link" data-title="Get Generic Plan Detail">Get Generic Plan Detail</a>
-                    </li>
-                    <li>
-                      <a href="#get-service-points" class="toc-h2 toc-link" data-title="Get Service Points">Get Service Points</a>
-                    </li>
-                    <li>
-                      <a href="#get-service-point-detail" class="toc-h2 toc-link" data-title="Get Service Point Detail">Get Service Point Detail</a>
-                    </li>
-                    <li>
-                      <a href="#get-usage-for-service-point" class="toc-h2 toc-link" data-title="Get Usage For Service Point">Get Usage For Service Point</a>
-                    </li>
-                    <li>
-                      <a href="#get-bulk-usage" class="toc-h2 toc-link" data-title="Get Bulk Usage">Get Bulk Usage</a>
-                    </li>
-                    <li>
-                      <a href="#get-usage-for-specific-service-points" class="toc-h2 toc-link" data-title="Get Usage For Specific Service Points">Get Usage For Specific Service Points</a>
-                    </li>
-                    <li>
-                      <a href="#get-der-for-service-point" class="toc-h2 toc-link" data-title="Get DER For Service Point">Get DER For Service Point</a>
-                    </li>
-                    <li>
-                      <a href="#get-bulk-der" class="toc-h2 toc-link" data-title="Get Bulk DER">Get Bulk DER</a>
-                    </li>
-                    <li>
-                      <a href="#get-der-for-specific-service-points" class="toc-h2 toc-link" data-title="Get DER For Specific Service Points">Get DER For Specific Service Points</a>
-                    </li>
-                    <li>
-                      <a href="#get-energy-accounts" class="toc-h2 toc-link" data-title="Get Energy Accounts">Get Energy Accounts</a>
-                    </li>
-                    <li>
-                      <a href="#get-energy-account-detail" class="toc-h2 toc-link" data-title="Get Energy Account Detail">Get Energy Account Detail</a>
-                    </li>
-                    <li>
-                      <a href="#get-agreed-payment-schedule" class="toc-h2 toc-link" data-title="Get Agreed Payment Schedule">Get Agreed Payment Schedule</a>
-                    </li>
-                    <li>
-                      <a href="#get-concessions" class="toc-h2 toc-link" data-title="Get Concessions">Get Concessions</a>
-                    </li>
-                    <li>
-                      <a href="#get-balance-for-energy-account" class="toc-h2 toc-link" data-title="Get Balance For Energy Account">Get Balance For Energy Account</a>
-                    </li>
-                    <li>
-                      <a href="#get-bulk-balances-energy" class="toc-h2 toc-link" data-title="Get Bulk Balances (Energy)">Get Bulk Balances (Energy)</a>
-                    </li>
-                    <li>
-                      <a href="#get-balances-for-specific-energy-accounts" class="toc-h2 toc-link" data-title="Get Balances For Specific Energy Accounts">Get Balances For Specific Energy Accounts</a>
-                    </li>
-                    <li>
-                      <a href="#get-invoices-for-account" class="toc-h2 toc-link" data-title="Get Invoices For Account">Get Invoices For Account</a>
-                    </li>
-                    <li>
-                      <a href="#get-bulk-invoices" class="toc-h2 toc-link" data-title="Get Bulk Invoices">Get Bulk Invoices</a>
-                    </li>
-                    <li>
-                      <a href="#get-invoices-for-specific-accounts" class="toc-h2 toc-link" data-title="Get Invoices For Specific Accounts">Get Invoices For Specific Accounts</a>
-                    </li>
-                    <li>
-                      <a href="#get-billing-for-account" class="toc-h2 toc-link" data-title="Get Billing For Account">Get Billing For Account</a>
-                    </li>
-                    <li>
-                      <a href="#get-bulk-billing" class="toc-h2 toc-link" data-title="Get Bulk Billing">Get Bulk Billing</a>
-                    </li>
-                    <li>
-                      <a href="#get-billing-for-specific-accounts" class="toc-h2 toc-link" data-title="Get Billing For Specific Accounts">Get Billing For Specific Accounts</a>
-                    </li>
-                    <li>
-                      <a href="#cdr-energy-api-schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
-                    </li>
+                  <li>
+                    <a href="#get-generic-plans" class="toc-h2 toc-link" data-title="Get Generic Plans">Get Generic Plans</a>
+                  </li>
+                  <li>
+                    <a href="#get-generic-plan-detail" class="toc-h2 toc-link" data-title="Get Generic Plan Detail">Get Generic Plan Detail</a>
+                  </li>
+                  <li>
+                    <a href="#get-service-points" class="toc-h2 toc-link" data-title="Get Service Points">Get Service Points</a>
+                  </li>
+                  <li>
+                    <a href="#get-service-point-detail" class="toc-h2 toc-link" data-title="Get Service Point Detail">Get Service Point Detail</a>
+                  </li>
+                  <li>
+                    <a href="#get-usage-for-service-point" class="toc-h2 toc-link" data-title="Get Usage For Service Point">Get Usage For Service Point</a>
+                  </li>
+                  <li>
+                    <a href="#get-bulk-usage" class="toc-h2 toc-link" data-title="Get Bulk Usage">Get Bulk Usage</a>
+                  </li>
+                  <li>
+                    <a href="#get-usage-for-specific-service-points" class="toc-h2 toc-link" data-title="Get Usage For Specific Service Points">Get Usage For Specific Service Points</a>
+                  </li>
+                  <li>
+                    <a href="#get-der-for-service-point" class="toc-h2 toc-link" data-title="Get DER For Service Point">Get DER For Service Point</a>
+                  </li>
+                  <li>
+                    <a href="#get-bulk-der" class="toc-h2 toc-link" data-title="Get Bulk DER">Get Bulk DER</a>
+                  </li>
+                  <li>
+                    <a href="#get-der-for-specific-service-points" class="toc-h2 toc-link" data-title="Get DER For Specific Service Points">Get DER For Specific Service Points</a>
+                  </li>
+                  <li>
+                    <a href="#get-energy-accounts" class="toc-h2 toc-link" data-title="Get Energy Accounts">Get Energy Accounts</a>
+                  </li>
+                  <li>
+                    <a href="#get-energy-account-detail" class="toc-h2 toc-link" data-title="Get Energy Account Detail">Get Energy Account Detail</a>
+                  </li>
+                  <li>
+                    <a href="#get-agreed-payment-schedule" class="toc-h2 toc-link" data-title="Get Agreed Payment Schedule">Get Agreed Payment Schedule</a>
+                  </li>
+                  <li>
+                    <a href="#get-concessions" class="toc-h2 toc-link" data-title="Get Concessions">Get Concessions</a>
+                  </li>
+                  <li>
+                    <a href="#get-balance-for-energy-account" class="toc-h2 toc-link" data-title="Get Balance For Energy Account">Get Balance For Energy Account</a>
+                  </li>
+                  <li>
+                    <a href="#get-bulk-balances-energy" class="toc-h2 toc-link" data-title="Get Bulk Balances (Energy)">Get Bulk Balances (Energy)</a>
+                  </li>
+                  <li>
+                    <a href="#get-balances-for-specific-energy-accounts" class="toc-h2 toc-link" data-title="Get Balances For Specific Energy Accounts">Get Balances For Specific Energy Accounts</a>
+                  </li>
+                  <li>
+                    <a href="#get-invoices-for-account" class="toc-h2 toc-link" data-title="Get Invoices For Account">Get Invoices For Account</a>
+                  </li>
+                  <li>
+                    <a href="#get-bulk-invoices" class="toc-h2 toc-link" data-title="Get Bulk Invoices">Get Bulk Invoices</a>
+                  </li>
+                  <li>
+                    <a href="#get-invoices-for-specific-accounts" class="toc-h2 toc-link" data-title="Get Invoices For Specific Accounts">Get Invoices For Specific Accounts</a>
+                  </li>
+                  <li>
+                    <a href="#get-billing-for-account" class="toc-h2 toc-link" data-title="Get Billing For Account">Get Billing For Account</a>
+                  </li>
+                  <li>
+                    <a href="#get-bulk-billing" class="toc-h2 toc-link" data-title="Get Bulk Billing">Get Bulk Billing</a>
+                  </li>
+                  <li>
+                    <a href="#get-billing-for-specific-accounts" class="toc-h2 toc-link" data-title="Get Billing For Specific Accounts">Get Billing For Specific Accounts</a>
+                  </li>
+                  <li>
+                    <a href="#cdr-energy-api-schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyplanlistresponse" class="toc-h2 toc-link" data-title="EnergyPlanListResponse">EnergyPlanListResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyplanresponse" class="toc-h2 toc-link" data-title="EnergyPlanResponse">EnergyPlanResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyservicepointlistresponse" class="toc-h2 toc-link" data-title="EnergyServicePointListResponse">EnergyServicePointListResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyservicepointdetailresponse" class="toc-h2 toc-link" data-title="EnergyServicePointDetailResponse">EnergyServicePointDetailResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyusagelistresponse" class="toc-h2 toc-link" data-title="EnergyUsageListResponse">EnergyUsageListResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyderlistresponse" class="toc-h2 toc-link" data-title="EnergyDerListResponse">EnergyDerListResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyderdetailresponse" class="toc-h2 toc-link" data-title="EnergyDerDetailResponse">EnergyDerDetailResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyaccountlistresponse" class="toc-h2 toc-link" data-title="EnergyAccountListResponse">EnergyAccountListResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyaccountdetailresponse" class="toc-h2 toc-link" data-title="EnergyAccountDetailResponse">EnergyAccountDetailResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergypaymentscheduleresponse" class="toc-h2 toc-link" data-title="EnergyPaymentScheduleResponse">EnergyPaymentScheduleResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyconcessionsresponse" class="toc-h2 toc-link" data-title="EnergyConcessionsResponse">EnergyConcessionsResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergybalancelistresponse" class="toc-h2 toc-link" data-title="EnergyBalanceListResponse">EnergyBalanceListResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergybalanceresponse" class="toc-h2 toc-link" data-title="EnergyBalanceResponse">EnergyBalanceResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyinvoicelistresponse" class="toc-h2 toc-link" data-title="EnergyInvoiceListResponse">EnergyInvoiceListResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergybillinglistresponse" class="toc-h2 toc-link" data-title="EnergyBillingListResponse">EnergyBillingListResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSerrorlistresponse" class="toc-h2 toc-link" data-title="ErrorListResponse">ErrorListResponse</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyplan" class="toc-h2 toc-link" data-title="EnergyPlan">EnergyPlan</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyplandetail" class="toc-h2 toc-link" data-title="EnergyPlanDetail">EnergyPlanDetail</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyplancontract" class="toc-h2 toc-link" data-title="EnergyPlanContract">EnergyPlanContract</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyplancontractfull" class="toc-h2 toc-link" data-title="EnergyPlanContractFull">EnergyPlanContractFull</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyplancontrolledload" class="toc-h2 toc-link" data-title="EnergyPlanControlledLoad">EnergyPlanControlledLoad</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyplanincentives" class="toc-h2 toc-link" data-title="EnergyPlanIncentives">EnergyPlanIncentives</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyplandiscounts" class="toc-h2 toc-link" data-title="EnergyPlanDiscounts">EnergyPlanDiscounts</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyplangreenpowercharges" class="toc-h2 toc-link" data-title="EnergyPlanGreenPowerCharges">EnergyPlanGreenPowerCharges</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyplaneligibility" class="toc-h2 toc-link" data-title="EnergyPlanEligibility">EnergyPlanEligibility</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyplanfees" class="toc-h2 toc-link" data-title="EnergyPlanFees">EnergyPlanFees</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyplansolarfeedintariff" class="toc-h2 toc-link" data-title="EnergyPlanSolarFeedInTariff">EnergyPlanSolarFeedInTariff</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyplantariffperiod" class="toc-h2 toc-link" data-title="EnergyPlanTariffPeriod">EnergyPlanTariffPeriod</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyservicepoint" class="toc-h2 toc-link" data-title="EnergyServicePoint">EnergyServicePoint</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyservicepointdetail" class="toc-h2 toc-link" data-title="EnergyServicePointDetail">EnergyServicePointDetail</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyusageread" class="toc-h2 toc-link" data-title="EnergyUsageRead">EnergyUsageRead</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyderrecord" class="toc-h2 toc-link" data-title="EnergyDerRecord">EnergyDerRecord</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyaccountbase" class="toc-h2 toc-link" data-title="EnergyAccountBase">EnergyAccountBase</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyaccount" class="toc-h2 toc-link" data-title="EnergyAccount">EnergyAccount</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyaccountdetail" class="toc-h2 toc-link" data-title="EnergyAccountDetail">EnergyAccountDetail</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergypaymentschedule" class="toc-h2 toc-link" data-title="EnergyPaymentSchedule">EnergyPaymentSchedule</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyconcession" class="toc-h2 toc-link" data-title="EnergyConcession">EnergyConcession</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyinvoice" class="toc-h2 toc-link" data-title="EnergyInvoice">EnergyInvoice</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyinvoicegasusagecharges" class="toc-h2 toc-link" data-title="EnergyInvoiceGasUsageCharges">EnergyInvoiceGasUsageCharges</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyinvoiceelectricityusagecharges" class="toc-h2 toc-link" data-title="EnergyInvoiceElectricityUsageCharges">EnergyInvoiceElectricityUsageCharges</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergyinvoiceaccountcharges" class="toc-h2 toc-link" data-title="EnergyInvoiceAccountCharges">EnergyInvoiceAccountCharges</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergybillingtransaction" class="toc-h2 toc-link" data-title="EnergyBillingTransaction">EnergyBillingTransaction</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergybillingusagetransaction" class="toc-h2 toc-link" data-title="EnergyBillingUsageTransaction">EnergyBillingUsageTransaction</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergybillingdemandtransaction" class="toc-h2 toc-link" data-title="EnergyBillingDemandTransaction">EnergyBillingDemandTransaction</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergybillingonceofftransaction" class="toc-h2 toc-link" data-title="EnergyBillingOnceOffTransaction">EnergyBillingOnceOffTransaction</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergybillingothertransaction" class="toc-h2 toc-link" data-title="EnergyBillingOtherTransaction">EnergyBillingOtherTransaction</a>
+                  </li>
+                  <li>
+                    <a href="#tocSenergybillingpaymenttransaction" class="toc-h2 toc-link" data-title="EnergyBillingPaymentTransaction">EnergyBillingPaymentTransaction</a>
+                  </li>
+                  <li>
+                    <a href="#tocSlinks" class="toc-h2 toc-link" data-title="Links">Links</a>
+                  </li>
+                  <li>
+                    <a href="#tocSmeta" class="toc-h2 toc-link" data-title="Meta">Meta</a>
+                  </li>
+                  <li>
+                    <a href="#tocSlinkspaginated" class="toc-h2 toc-link" data-title="LinksPaginated">LinksPaginated</a>
+                  </li>
+                  <li>
+                    <a href="#tocSmetapaginated" class="toc-h2 toc-link" data-title="MetaPaginated">MetaPaginated</a>
+                  </li>
               </ul>
           </li>
             <li class="toc-child">
               <a href="#common-apis" class="toc-h1 toc-link" data-title="Common APIs">Common APIs</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#get-customer" class="toc-h2 toc-link" data-title="Get Customer">Get Customer</a>
-                    </li>
-                    <li>
-                      <a href="#get-customer-detail" class="toc-h2 toc-link" data-title="Get Customer Detail">Get Customer Detail</a>
-                    </li>
-                    <li>
-                      <a href="#get-status" class="toc-h2 toc-link" data-title="Get Status">Get Status</a>
-                    </li>
-                    <li>
-                      <a href="#get-outages" class="toc-h2 toc-link" data-title="Get Outages">Get Outages</a>
-                    </li>
-                    <li>
-                      <a href="#cdr-common-api-schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
-                    </li>
+                  <li>
+                    <a href="#get-customer" class="toc-h2 toc-link" data-title="Get Customer">Get Customer</a>
+                  </li>
+                  <li>
+                    <a href="#get-customer-detail" class="toc-h2 toc-link" data-title="Get Customer Detail">Get Customer Detail</a>
+                  </li>
+                  <li>
+                    <a href="#get-status" class="toc-h2 toc-link" data-title="Get Status">Get Status</a>
+                  </li>
+                  <li>
+                    <a href="#get-outages" class="toc-h2 toc-link" data-title="Get Outages">Get Outages</a>
+                  </li>
+                  <li>
+                    <a href="#cdr-common-api-schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsecommondiscoverystatus" class="toc-h2 toc-link" data-title="ResponseCommonDiscoveryStatus">ResponseCommonDiscoveryStatus</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsediscoveryoutageslist" class="toc-h2 toc-link" data-title="ResponseDiscoveryOutagesList">ResponseDiscoveryOutagesList</a>
+                  </li>
+                  <li>
+                    <a href="#tocSdiscoveryoutage" class="toc-h2 toc-link" data-title="DiscoveryOutage">DiscoveryOutage</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsecommoncustomer" class="toc-h2 toc-link" data-title="ResponseCommonCustomer">ResponseCommonCustomer</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsecommoncustomerdetail" class="toc-h2 toc-link" data-title="ResponseCommonCustomerDetail">ResponseCommonCustomerDetail</a>
+                  </li>
+                  <li>
+                    <a href="#tocScommonperson" class="toc-h2 toc-link" data-title="CommonPerson">CommonPerson</a>
+                  </li>
+                  <li>
+                    <a href="#tocScommonpersondetail" class="toc-h2 toc-link" data-title="CommonPersonDetail">CommonPersonDetail</a>
+                  </li>
+                  <li>
+                    <a href="#tocScommonorganisation" class="toc-h2 toc-link" data-title="CommonOrganisation">CommonOrganisation</a>
+                  </li>
+                  <li>
+                    <a href="#tocScommonorganisationdetail" class="toc-h2 toc-link" data-title="CommonOrganisationDetail">CommonOrganisationDetail</a>
+                  </li>
+                  <li>
+                    <a href="#tocScommonphonenumber" class="toc-h2 toc-link" data-title="CommonPhoneNumber">CommonPhoneNumber</a>
+                  </li>
+                  <li>
+                    <a href="#tocScommonemailaddress" class="toc-h2 toc-link" data-title="CommonEmailAddress">CommonEmailAddress</a>
+                  </li>
+                  <li>
+                    <a href="#tocScommonphysicaladdresswithpurpose" class="toc-h2 toc-link" data-title="CommonPhysicalAddressWithPurpose">CommonPhysicalAddressWithPurpose</a>
+                  </li>
+                  <li>
+                    <a href="#tocScommonphysicaladdress" class="toc-h2 toc-link" data-title="CommonPhysicalAddress">CommonPhysicalAddress</a>
+                  </li>
+                  <li>
+                    <a href="#tocScommonsimpleaddress" class="toc-h2 toc-link" data-title="CommonSimpleAddress">CommonSimpleAddress</a>
+                  </li>
+                  <li>
+                    <a href="#tocScommonpafaddress" class="toc-h2 toc-link" data-title="CommonPAFAddress">CommonPAFAddress</a>
+                  </li>
+                  <li>
+                    <a href="#tocSlinks" class="toc-h2 toc-link" data-title="Links">Links</a>
+                  </li>
+                  <li>
+                    <a href="#tocSmeta" class="toc-h2 toc-link" data-title="Meta">Meta</a>
+                  </li>
+                  <li>
+                    <a href="#tocSmetaerror" class="toc-h2 toc-link" data-title="MetaError">MetaError</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponseerrorlistv2" class="toc-h2 toc-link" data-title="ResponseErrorListV2">ResponseErrorListV2</a>
+                  </li>
               </ul>
           </li>
             <li class="toc-child">
               <a href="#admin-apis" class="toc-h1 toc-link" data-title="Admin APIs">Admin APIs</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#metadata-update" class="toc-h2 toc-link" data-title="Metadata Update">Metadata Update</a>
-                    </li>
-                    <li>
-                      <a href="#get-metrics" class="toc-h2 toc-link" data-title="Get Metrics">Get Metrics</a>
-                    </li>
-                    <li>
-                      <a href="#cdr-admin-api-schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
-                    </li>
+                  <li>
+                    <a href="#metadata-update" class="toc-h2 toc-link" data-title="Metadata Update">Metadata Update</a>
+                  </li>
+                  <li>
+                    <a href="#get-metrics" class="toc-h2 toc-link" data-title="Get Metrics">Get Metrics</a>
+                  </li>
+                  <li>
+                    <a href="#cdr-admin-api-schemas" class="toc-h2 toc-link" data-title="Schemas">Schemas</a>
+                  </li>
+                  <li>
+                    <a href="#tocSrequestmetadataupdate" class="toc-h2 toc-link" data-title="RequestMetaDataUpdate">RequestMetaDataUpdate</a>
+                  </li>
+                  <li>
+                    <a href="#tocSresponsemetricslistv3" class="toc-h2 toc-link" data-title="ResponseMetricsListV3">ResponseMetricsListV3</a>
+                  </li>
+                  <li>
+                    <a href="#tocSavailabilitymetrics" class="toc-h2 toc-link" data-title="AvailabilityMetrics">AvailabilityMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSperformancemetrics" class="toc-h2 toc-link" data-title="PerformanceMetrics">PerformanceMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSinvocationmetricsv2" class="toc-h2 toc-link" data-title="InvocationMetricsV2">InvocationMetricsV2</a>
+                  </li>
+                  <li>
+                    <a href="#tocSaverageresponsemetricsv2" class="toc-h2 toc-link" data-title="AverageResponseMetricsV2">AverageResponseMetricsV2</a>
+                  </li>
+                  <li>
+                    <a href="#tocSsessioncountmetrics" class="toc-h2 toc-link" data-title="SessionCountMetrics">SessionCountMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSaveragetpsmetrics" class="toc-h2 toc-link" data-title="AverageTPSMetrics">AverageTPSMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSpeaktpsmetrics" class="toc-h2 toc-link" data-title="PeakTPSMetrics">PeakTPSMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSerrormetrics" class="toc-h2 toc-link" data-title="ErrorMetrics">ErrorMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSrejectionmetricsv2" class="toc-h2 toc-link" data-title="RejectionMetricsV2">RejectionMetricsV2</a>
+                  </li>
+                  <li>
+                    <a href="#tocSsecondaryholdermetrics" class="toc-h2 toc-link" data-title="SecondaryHolderMetrics">SecondaryHolderMetrics</a>
+                  </li>
+                  <li>
+                    <a href="#tocSlinks" class="toc-h2 toc-link" data-title="Links">Links</a>
+                  </li>
+                  <li>
+                    <a href="#tocSmeta" class="toc-h2 toc-link" data-title="Meta">Meta</a>
+                  </li>
               </ul>
           </li>
             <li class="toc-group">
@@ -663,9 +1182,9 @@
             <li class="toc-child">
               <a href="#secondary-responsibility" class="toc-h1 toc-link" data-title="Secondary Responsibility">Secondary Responsibility</a>
               <ul class="toc-list-h2">
-                    <li>
-                      <a href="#energy" class="toc-h2 toc-link" data-title="Energy">Energy</a>
-                    </li>
+                  <li>
+                    <a href="#energy" class="toc-h2 toc-link" data-title="Energy">Energy</a>
+                  </li>
               </ul>
           </li>
             <li class="toc-group">

--- a/slate/source/layouts/layout.erb
+++ b/slate/source/layouts/layout.erb
@@ -82,11 +82,9 @@ under the License.
             <% if h1[:children].length > 0 %>
               <ul class="toc-list-h2">
                 <% h1[:children].each do |h2| %>
-                  <% if h2[:css_class] != 'schema-toc' %>
-                    <li>
-                      <a href="#<%= h2[:id] %>" class="toc-h2 toc-link" data-title="<%= h2[:title] %>"><%= h2[:content] %></a>
-                    </li>
-                  <% end %>
+                  <li>
+                    <a href="#<%= h2[:id] %>" class="toc-h2 toc-link" data-title="<%= h2[:title] %>"><%= h2[:content] %></a>
+                  </li>
                 <% end %>
               </ul>
             <% end %>

--- a/slate/source/layouts/no_code_panel_layout.erb
+++ b/slate/source/layouts/no_code_panel_layout.erb
@@ -77,11 +77,9 @@ under the License.
             <% if h1[:children].length > 0 %>
               <ul class="toc-list-h2">
                 <% h1[:children].each do |h2| %>
-                  <% if h2[:css_class] != 'schema-toc' %>
-                    <li>
-                      <a href="#<%= h2[:id] %>" class="toc-h2 toc-link" data-title="<%= h2[:title] %>"><%= h2[:content] %></a>
-                    </li>
-                  <% end %>
+                  <li>
+                    <a href="#<%= h2[:id] %>" class="toc-h2 toc-link" data-title="<%= h2[:title] %>"><%= h2[:content] %></a>
+                  </li>
                 <% end %>
               </ul>
             <% end %>


### PR DESCRIPTION
Changes to slate to restore the schema entries to the table of contents.  No changes have been made to any of the content of the standards in this PR.  Only the publishing mechanism has been modified.